### PR TITLE
optional mqtt authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ bash <(wget -qO- https://raw.githubusercontent.com/jac459/meta/Release/update.sh
 ## C - How to install meta if You are a Raspberry/Linux Black Belt
 - The meta can be installed like any node.js program by taking the files and typing "npm install".
 - The meta NEEDS MQTT to run. NODE-RED is highly advised.
-- MQTT is expected to not have any authentication.
+- By default, MQTT is expected to not have any authentication. You can connect to a local MQTT host with authentication by setting the username and password in settings.js (uncomment the specific lines).
 - Meta-core driver expect node-red, mqtt and meta to by run by pm2. Not by services. This is not a big deal if you don't plan to use it.
 - The meta expect 2 folders: library (for all drivers) and active (for activated drivers).
 - You can configure the name, port of the meta in order to run multiple instances of the meta (have different names and port for the neeo). This is very useful if you want to run a new version of the meta without taking risk on your previous version.

--- a/meta.js
+++ b/meta.js
@@ -942,7 +942,12 @@ if (process.argv.length>2) {
 
 getConfig().then(() => {
     networkDiscovery();
-    mqttClient = mqtt.connect('mqtt://' + settings.mqtt, {clientId:settings.mqttClientId}); // Always connect to the local mqtt broker
+    var options = {
+      clientId: settings.mqttClientId,
+      username: settings.mqttUsername,
+      password: settings.mqttPassword
+    }
+    mqttClient = mqtt.connect('mqtt://' + settings.mqtt, options); // Always connect to the local mqtt broker
     mqttClient.setMaxListeners(0); //CAREFULL OF MEMORY LEAKS HERE.
     mqttClient.on('connect', () => {
       metaLog({type:LOG_TYPE.WARNING, content:"Connection to MQTT Broker Successful."});

--- a/settings.js
+++ b/settings.js
@@ -7,6 +7,8 @@ var settings =
   'runtimeName' : '.meta',
   'defaultPort' : '4016',
   'mqttClientId' : 'meta',
+  // 'mqttUsername' : 'username',
+  // 'mqttPassword' : 'password',
   'activeLibrary' : './active'
 }
   


### PR DESCRIPTION
@jac459 I reopened this PR, rebased on the current Release branch.

I am running meta, but with a configured mqtt broker on the same host with authentication as it is used for other purposes as well (openHAB integration). I want to keep it that way. This PR should not break the standard behaviour when no username and password configured, but allows configuring it in settings.js.

I hope you will consider merging this.